### PR TITLE
Remove console log from sidebar

### DIFF
--- a/frontend/components/Layout/Sidebar.tsx
+++ b/frontend/components/Layout/Sidebar.tsx
@@ -4,7 +4,6 @@ import { AuthContext } from '../../contexts/AuthContext'
 
 const Sidebar: React.FC = () => {
   const { user } = useContext(AuthContext)
-  console.log(user)
   return (
     <aside className='w-64 bg-white shadow-md p-4'>
       <h2 className='text-lg font-semibold mb-4'>Admin Panel</h2>


### PR DESCRIPTION
## Summary
- remove lingering debug `console.log` from `Sidebar`

## Testing
- `npm run lint` *(fails: next not found)*