### PR TITLE
Adjust test mocks for keycloak-aware services

### DIFF
--- a/backend/src/subjects/subjects.service.spec.ts
+++ b/backend/src/subjects/subjects.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository, QueryFailedError } from 'typeorm';
+import { Repository } from 'typeorm';
 import { SubjectsService } from './subjects.service';
 import { SubjectEntity } from './entities/subject.entity';
 import { ClassEntity } from '../classes/entities/class.entity';
@@ -63,6 +63,10 @@ describe('SubjectsService', () => {
     );
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
@@ -72,7 +76,7 @@ describe('SubjectsService', () => {
     const createdEntity = { ...baseMockSubjectEntity, ...createDto, id: 'new-uuid', classes: Promise.resolve([]) };
 
     it('should create and return a subject DTO if name and code are unique', async () => {
-      repository.findOne.mockResolvedValue(null);
+      repository.findOne.mockResolvedValueOnce(null);
       repository.create.mockReturnValue(createdEntity);
       repository.save.mockResolvedValue(createdEntity);
 
@@ -94,7 +98,7 @@ describe('SubjectsService', () => {
   describe('findOne', () => {
     it('should return a subject DTO with classes if found', async () => {
       const subjectWithClasses = { ...baseMockSubjectEntity, classes: Promise.resolve([new ClassEntity()]) };
-      repository.findOne.mockResolvedValue(subjectWithClasses);
+      repository.findOne.mockResolvedValueOnce(subjectWithClasses);
       const result = await service.findOne('subject-uuid-1', 'school-uuid-1');
       expect(result.classes.length).toBeGreaterThan(0);
     });
@@ -105,10 +109,10 @@ describe('SubjectsService', () => {
     const updatedEntity = { ...baseMockSubjectEntity, ...updateDto };
 
     it('should update and return a subject DTO if found', async () => {
-        repository.findOneBy.mockResolvedValue(baseMockSubjectEntity);
-        repository.findOne.mockResolvedValue(null); // for conflict check
+        repository.findOneBy.mockResolvedValueOnce(baseMockSubjectEntity);
+        repository.findOne.mockResolvedValueOnce(null); // for conflict check
         repository.save.mockResolvedValue(updatedEntity);
-        repository.findOne.mockResolvedValue(updatedEntity); // for the final fetch
+        repository.findOne.mockResolvedValueOnce(updatedEntity); // for the final fetch
         const result = await service.update('subject-uuid-1', updateDto, 'school-uuid-1');
         expect(result.name).toEqual(updateDto.name);
       });


### PR DESCRIPTION
## Summary
- stabilize the classes service tests by providing complete subject and teacher mocks and clearing jest state between runs
- harden the students service specs to cover conflict scenarios by emulating repository failures that occur with keycloak-backed uniqueness checks
- align the subjects and users service unit tests with new keycloak behavior, ensuring deterministic repository responses and clearer expectations

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d619b91eb48321b4bc81052d84dbb4